### PR TITLE
feat: support a matrix combination of connectors for tests

### DIFF
--- a/gradle/libs.0.7.6.versions.toml
+++ b/gradle/libs.0.7.6.versions.toml
@@ -1,0 +1,20 @@
+[metadata]
+format.version = "1.1"
+
+[versions]
+tractusx = "0.7.6"
+edc = "0.7.2"
+
+[libraries]
+tx-edc-controlplane-postgresql-hashicorp-vault = { module = "org.eclipse.tractusx.edc:edc-controlplane-postgresql-hashicorp-vault", version.ref = "tractusx" }
+tx-edc-dataplane-postgresql-hashicorp-vault = { module = "org.eclipse.tractusx.edc:edc-dataplane-hashicorp-vault", version.ref = "tractusx" }
+edc-boot-spi = { module = "org.eclipse.edc:boot-spi", version.ref = "edc" }
+edc-core-spi = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
+tx-bdrs-client-spi = { module = "org.eclipse.tractusx.edc:bdrs-client-spi", version.ref = "tractusx" }
+edc-identity-trust-sts-remote-client = { module = "org.eclipse.edc:identity-trust-sts-remote-client", version.ref = "edc" }
+edc-auth-oauth2-client = { module = "org.eclipse.edc:oauth2-client", version.ref = "edc" }
+edc-api-management-dataplaneselector = { module = "org.eclipse.edc:data-plane-selector-api", version.ref = "edc" }
+
+[plugins]
+shadow = { id = "com.gradleup.shadow", version = "8.3.5" }
+docker = { id = "com.bmuschko.docker-remote-api", version = "9.4.0" }

--- a/runtimes/076/controlplane-076/build.gradle.kts
+++ b/runtimes/076/controlplane-076/build.gradle.kts
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin
+
+plugins {
+    id("application")
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.docker)
+}
+
+dependencies {
+    runtimeOnly(libs076.tx.edc.controlplane.postgresql.hashicorp.vault) {
+        exclude(group = "org.eclipse.edc", "vault-hashicorp")
+        exclude(module = "bdrs-client")
+        exclude(module = "tx-iatp-sts-dim")
+    }
+    runtimeOnly(project(":runtimes:stable:extensions"))
+    runtimeOnly(libs076.edc.identity.trust.sts.remote.client)
+    runtimeOnly(libs076.edc.auth.oauth2.client)
+    runtimeOnly(libs076.edc.api.management.dataplaneselector)
+}
+
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
+    exclude("**/pom.properties", "**/pom.xml")
+    mergeServiceFiles()
+    archiveFileName.set("${project.name}.jar")
+}
+
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+
+}
+
+edcBuild {
+    publish.set(false)
+}
+
+// configure the "dockerize" task
+tasks.register("dockerize", DockerBuildImage::class) {
+    val dockerContextDir = project.projectDir
+    dockerFile.set(file("$dockerContextDir/src/main/docker/Dockerfile"))
+    images.add("${project.name}:${libs076.versions.tractusx.get()}")
+    images.add("${project.name}:latest")
+    // specify platform with the -Dplatform flag:
+    if (System.getProperty("platform") != null)
+        platform.set(System.getProperty("platform"))
+    buildArgs.put("JAR", "build/libs/${project.name}.jar")
+    inputDir.set(file(dockerContextDir))
+    dependsOn(tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
+}

--- a/runtimes/076/controlplane-076/src/main/docker/Dockerfile
+++ b/runtimes/076/controlplane-076/src/main/docker/Dockerfile
@@ -1,0 +1,18 @@
+# -buster is required to have apt available
+FROM eclipse-temurin:23.0.2_7-jre-alpine
+
+# Optional JVM arguments, such as memory settings
+ARG JVM_ARGS=""
+ARG JAR
+
+RUN apk --no-cache add curl
+
+WORKDIR /app
+
+COPY ${JAR} edc-controlplane.jar
+
+# Use "exec" for graceful termination (SIGINT) to reach JVM.
+# ARG can not be used in ENTRYPOINT so storing value in an ENV variable
+ENV ENV_JVM_ARGS=$JVM_ARGS
+# use the "exec" syntax so that SIGINT reaches the JVM -> graceful termination
+CMD ["sh", "-c", "exec java -Djava.security.egd=file:/dev/urandom -jar edc-controlplane.jar"]

--- a/runtimes/076/dataplane-076/build.gradle.kts
+++ b/runtimes/076/dataplane-076/build.gradle.kts
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin
+
+plugins {
+    id("application")
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.docker)
+}
+
+dependencies {
+    runtimeOnly(libs076.tx.edc.dataplane.postgresql.hashicorp.vault) {
+        exclude(group = "org.eclipse.edc", "vault-hashicorp")
+        exclude(module = "tx-iatp-sts-dim")
+    }
+    runtimeOnly(project(":runtimes:stable:extensions"))
+    runtimeOnly(libs076.edc.identity.trust.sts.remote.client)
+    runtimeOnly(libs076.edc.auth.oauth2.client)
+
+}
+
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
+    exclude("**/pom.properties", "**/pom.xml")
+    mergeServiceFiles()
+    archiveFileName.set("${project.name}.jar")
+}
+
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+}
+
+edcBuild {
+    publish.set(false)
+}
+
+// configure the "dockerize" task
+tasks.register("dockerize", DockerBuildImage::class) {
+    val dockerContextDir = project.projectDir
+    dockerFile.set(file("$dockerContextDir/src/main/docker/Dockerfile"))
+    images.add("${project.name}:${libs076.versions.tractusx.get()}")
+    images.add("${project.name}:latest")
+    // specify platform with the -Dplatform flag:
+    if (System.getProperty("platform") != null)
+        platform.set(System.getProperty("platform"))
+    buildArgs.put("JAR", "build/libs/${project.name}.jar")
+    inputDir.set(file(dockerContextDir))
+    dependsOn(tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
+}

--- a/runtimes/076/dataplane-076/src/main/docker/Dockerfile
+++ b/runtimes/076/dataplane-076/src/main/docker/Dockerfile
@@ -1,0 +1,18 @@
+# -buster is required to have apt available
+FROM eclipse-temurin:23.0.2_7-jre-alpine
+
+# Optional JVM arguments, such as memory settings
+ARG JVM_ARGS=""
+ARG JAR
+
+RUN apk --no-cache add curl
+
+WORKDIR /app
+
+COPY ${JAR} edc-dataplane.jar
+
+# Use "exec" for graceful termination (SIGINT) to reach JVM.
+# ARG can not be used in ENTRYPOINT so storing value in an ENV variable
+ENV ENV_JVM_ARGS=$JVM_ARGS
+# use the "exec" syntax so that SIGINT reaches the JVM -> graceful termination
+CMD ["sh", "-c", "exec java -Djava.security.egd=file:/dev/urandom -jar edc-dataplane.jar"]

--- a/runtimes/076/extensions-076/build.gradle.kts
+++ b/runtimes/076/extensions-076/build.gradle.kts
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+
+    implementation(libs076.edc.boot.spi)
+    implementation(libs076.edc.core.spi)
+    implementation(libs076.tx.bdrs.client.spi)
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/runtimes/076/extensions-076/src/main/java/org/eclipse/tractusx/edc/compatibility/tests/AudienceSeedExtension.java
+++ b/runtimes/076/extensions-076/src/main/java/org/eclipse/tractusx/edc/compatibility/tests/AudienceSeedExtension.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.edc.compatibility.tests;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.iam.AudienceResolver;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+@Extension("Bdrs Seed Extension")
+public class AudienceSeedExtension implements ServiceExtension {
+
+
+    public static final String BDRS_TESTING_PREFIX = "testing.edc.bdrs";
+
+    public static final String BDRS_TESTING_KEY = "key";
+    public static final String BDRS_TESTING_VALUE = "value";
+
+    private Map<String, String> dids;
+
+    @Provider
+    public BdrsClient bdrsClient(ServiceExtensionContext context) {
+        var dids = readDidsMapping(context);
+        return dids::get;
+    }
+
+    @Provider
+    public AudienceResolver audienceResolver(ServiceExtensionContext context) {
+        var dids = readDidsMapping(context);
+        return message -> Result.success(dids.get(message.getCounterPartyId()));
+    }
+
+    private Map<String, String> readDidsMapping(ServiceExtensionContext context) {
+        if (dids == null) {
+            var config = context.getConfig(BDRS_TESTING_PREFIX);
+            dids = config.partition().map((partition) -> {
+                var key = partition.getString(BDRS_TESTING_KEY);
+                var value = partition.getString(BDRS_TESTING_VALUE);
+                return Map.entry(key, value);
+            }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+        return dids;
+    }
+}

--- a/runtimes/076/extensions-076/src/main/java/org/eclipse/tractusx/edc/compatibility/tests/VaultSeedExtension.java
+++ b/runtimes/076/extensions-076/src/main/java/org/eclipse/tractusx/edc/compatibility/tests/VaultSeedExtension.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.edc.compatibility.tests;
+
+import org.eclipse.edc.runtime.metamodel.annotation.CoreExtension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.util.Map;
+
+@CoreExtension
+public class VaultSeedExtension implements ServiceExtension {
+
+    public static final String VAULT_TESTING_PREFIX = "testing.edc.vaults";
+
+    public static final String VAULT_TESTING_KEY = "key";
+    public static final String VAULT_TESTING_VALUE = "value";
+
+    @Inject
+    private Vault vault;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+
+        var config = context.getConfig(VAULT_TESTING_PREFIX);
+        var secrets = config.partition().map((partition) -> {
+            var key = partition.getString(VAULT_TESTING_KEY);
+            var value = partition.getString(VAULT_TESTING_VALUE);
+            return Map.entry(key, value);
+        }).toList();
+
+        secrets.forEach(secret -> vault.storeSecret(secret.getKey(), secret.getValue()));
+    }
+}

--- a/runtimes/076/extensions-076/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/runtimes/076/extensions-076/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,21 @@
+################################################################################
+# Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+org.eclipse.tractusx.edc.compatibility.tests.VaultSeedExtension
+org.eclipse.tractusx.edc.compatibility.tests.AudienceSeedExtension

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,9 @@ dependencyResolutionManagement {
         create("stableLibs") {
             from(files("./gradle/libs.stable.versions.toml"))
         }
+        create("libs076") {
+            from(files("./gradle/libs.0.7.6.versions.toml"))
+        }
     }
 }
 
@@ -53,4 +56,7 @@ include(":runtimes:snapshot:dataplane-snapshot")
 include(":runtimes:stable:controlplane-stable")
 include(":runtimes:stable:dataplane-stable")
 include(":runtimes:stable:extensions")
+include(":runtimes:076:controlplane-076")
+include(":runtimes:076:dataplane-076")
+include(":runtimes:076:stable:extensions-076")
 include(":tests:compatibility-tests")

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/AbstractTest.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/AbstractTest.java
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.edc.compatibility.tests;
+
+import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.spi.iam.AudienceResolver;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.tractusx.edc.compatibility.tests.fixtures.BaseParticipant;
+import org.eclipse.tractusx.edc.compatibility.tests.fixtures.DataspaceIssuer;
+import org.eclipse.tractusx.edc.compatibility.tests.fixtures.EdcDockerRuntimes;
+import org.eclipse.tractusx.edc.compatibility.tests.fixtures.IdentityHubParticipant;
+import org.eclipse.tractusx.edc.compatibility.tests.fixtures.LocalParticipant;
+import org.eclipse.tractusx.edc.compatibility.tests.fixtures.RemoteParticipant;
+import org.eclipse.tractusx.edc.compatibility.tests.fixtures.Runtimes;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndInstance.createDatabase;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.configureParticipant;
+import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.configureParticipantContext;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+
+public class AbstractTest {
+    private static final List<String> PROTOCOLS_TO_TEST = List.of("dataspace-protocol-http");
+    private static final List<EdcDockerRuntimes> RUNTIMES_TO_TEST = List.of(EdcDockerRuntimes.STABLE_CONNECTOR, EdcDockerRuntimes.STABLE_CONNECTOR_0_7_6);
+
+    protected static final IdentityHubParticipant IDENTITY_HUB_PARTICIPANT = IdentityHubParticipant.Builder.newInstance()
+            .name("identity-hub")
+            .id("identity-hub")
+            .build();
+
+    protected static final DataspaceIssuer ISSUER = DataspaceIssuer.Builder.newInstance().id("issuer").name("issuer")
+            .did(IDENTITY_HUB_PARTICIPANT.didFor("issuer"))
+            .build();
+
+
+    protected static final LocalParticipant LOCAL_PARTICIPANT = LocalParticipant.Builder.newInstance()
+            .name("local")
+            .id("local")
+            .sts(IDENTITY_HUB_PARTICIPANT.getSts())
+            .did(IDENTITY_HUB_PARTICIPANT.didFor("local"))
+            .trustedIssuer(ISSUER.getDid())
+            .build();
+
+
+    @Order(1)
+    @RegisterExtension
+    static final RuntimeExtension LOCAL_CONTROL_PLANE = new RuntimePerClassExtension(
+            Runtimes.CONTROL_PLANE.create("local-control-plane", LOCAL_PARTICIPANT.controlPlanePostgresConfiguration()));
+
+    @Order(2)
+    @RegisterExtension
+    static final RuntimeExtension LOCAL_DATA_PLANE = new RuntimePerClassExtension(
+            Runtimes.DATA_PLANE.create("local-data-plane", LOCAL_PARTICIPANT.dataPlanePostgresConfiguration()));
+
+    @Order(1)
+    @RegisterExtension
+    static final RuntimeExtension LOCAL_IDENTITY_HUB = new RuntimePerClassExtension(
+            Runtimes.IDENTITY_HUB.create("local-identity-hub", IDENTITY_HUB_PARTICIPANT.getConfiguration()));
+
+    private static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:16.4")
+            .withUsername("postgres")
+            .withPassword("password")
+            .withCreateContainerCmdModifier(cmd -> cmd.withName("postgres"));
+
+    private static final Map<EdcDockerRuntimes, RemoteParticipant> REMOTE_PARTICIPANT_MAP = new HashMap<>();
+
+    private static RemoteParticipant createParticipant(EdcDockerRuntimes runtime) {
+        String runtimeName = runtime.name().toLowerCase();
+        return RemoteParticipant.Builder.newInstance()
+                .name(runtimeName)
+                .id(runtimeName)
+                .sts(IDENTITY_HUB_PARTICIPANT.getSts())
+                .did(IDENTITY_HUB_PARTICIPANT.didFor(runtimeName))
+                .trustedIssuer(ISSUER.getDid())
+                .build();
+    }
+
+    @Order(0)
+    @RegisterExtension
+    static final BeforeAllCallback BOOSTRAP = context -> {
+        RUNTIMES_TO_TEST.forEach(runtime -> {
+            REMOTE_PARTICIPANT_MAP.put(runtime, createParticipant(runtime));
+        });
+
+        PG.setPortBindings(List.of("5432:5432"));
+        PG.start();
+        createDatabase(LOCAL_PARTICIPANT.getName());
+        Map<String, String> dids = new HashMap<>();
+        REMOTE_PARTICIPANT_MAP.values().forEach(participant -> {
+            dids.put(participant.getId(), participant.getDid());
+            createDatabase(participant.getName());
+        });
+        dids.put(LOCAL_PARTICIPANT.getId(), LOCAL_PARTICIPANT.getDid());
+        LOCAL_CONTROL_PLANE.registerServiceMock(BdrsClient.class, dids::get);
+        LOCAL_CONTROL_PLANE.registerServiceMock(AudienceResolver.class, message -> Result.success(dids.get(message.getCounterPartyId())));
+    };
+
+    protected static ClientAndServer providerDataSource;
+
+
+    private static void startRemoteRuntimes() {
+        REMOTE_PARTICIPANT_MAP.forEach((runtime, participant) -> {
+            List<BaseParticipant> participants = new ArrayList<>(REMOTE_PARTICIPANT_MAP.values().stream().filter(p -> !p.equals(participant)).toList());
+            participants.add(LOCAL_PARTICIPANT);
+            runtime.start(participant.controlPlaneEnv(participants), participant.dataPlaneEnv(participants));
+            configureParticipant(participant, ISSUER, IDENTITY_HUB_PARTICIPANT, LOCAL_IDENTITY_HUB);
+        });
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        configureParticipant(LOCAL_PARTICIPANT, ISSUER, IDENTITY_HUB_PARTICIPANT, LOCAL_IDENTITY_HUB);
+        startRemoteRuntimes();
+        configureParticipantContext(ISSUER, IDENTITY_HUB_PARTICIPANT, LOCAL_IDENTITY_HUB);
+
+        providerDataSource = startClientAndServer(getFreePort());
+        providerDataSource.when(HttpRequest.request()).respond(HttpResponse.response().withBody("data"));
+
+        var vault = LOCAL_DATA_PLANE.getService(Vault.class);
+        vault.storeSecret("private-key", LOCAL_PARTICIPANT.getPrivateKeyAsString());
+        vault.storeSecret("public-key", LOCAL_PARTICIPANT.getPublicKeyAsString());
+        vault.storeSecret("local-secret", "clientSecret");
+
+        var cpVault = LOCAL_CONTROL_PLANE.getService(Vault.class);
+        cpVault.storeSecret("local-secret", "clientSecret");
+    }
+
+    protected void initialise(BaseParticipant consumer, BaseParticipant provider, String protocol) {
+        provider.setProtocol(protocol);
+        consumer.setProtocol(protocol);
+        provider.waitForDataPlane();
+        providerDataSource.when(HttpRequest.request()).respond(HttpResponse.response("/source").withBody("data"));
+    }
+
+    protected @NotNull Map<String, Object> httpSourceDataAddress() {
+        return Map.of(EDC_NAMESPACE + "name", "transfer-test", EDC_NAMESPACE + "baseUrl", "http://localhost:" + providerDataSource.getPort() + "/source", EDC_NAMESPACE + "type", "HttpData", EDC_NAMESPACE + "proxyQueryParams", "true");
+    }
+
+    protected static class ParticipantsArgProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return createArgumentMatrix().stream();
+        }
+
+    }
+
+    private static List<Arguments> createArgumentMatrix() {
+        List<Arguments> testArguments = new ArrayList<>();
+        List<Participant> participants = new ArrayList<>(REMOTE_PARTICIPANT_MAP.values());
+        participants.add(LOCAL_PARTICIPANT);
+        for (int i = 0; i < participants.size(); i++) {
+            Participant consumer = participants.get(i);
+            for (int j = i + 1; j < participants.size(); j++) {
+                Participant provider = participants.get(j);
+                for (String protocol : PROTOCOLS_TO_TEST) {
+                    testArguments.add(Arguments.of(Named.of(consumer.getName(), consumer), Named.of(provider.getName(), provider), protocol));
+                    testArguments.add(Arguments.of(Named.of(provider.getName(), provider), Named.of(consumer.getName(), consumer), protocol));
+                }
+            }
+        }
+        return testArguments;
+    }
+
+
+}

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/RemoteParticipant.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/RemoteParticipant.java
@@ -34,8 +34,9 @@ public class RemoteParticipant extends BaseParticipant {
             "contractnegotiation", "policy", "transferprocess", "bpn",
             "policy-monitor", "edr", "dataplane", "accesstokendata", "dataplaneinstance");
 
-    public Map<String, String> controlPlaneEnv(BaseParticipant participant) {
-        return new HashMap<>() {
+    public Map<String, String> controlPlaneEnv(List<BaseParticipant> participants) {
+
+        Map<String, String> env = new HashMap<>() {
             {
                 put("EDC_PARTICIPANT_ID", id);
                 put("EDC_API_AUTH_KEY", API_KEY);
@@ -62,18 +63,24 @@ public class RemoteParticipant extends BaseParticipant {
                 put("TESTING_EDC_VAULTS_1_VALUE", "clientSecret");
                 put("EDC_IAM_ISSUER_ID", getDid());
                 put("EDC_IAM_DID_WEB_USE_HTTPS", "false");
-                put("TESTING_EDC_BDRS_1_KEY", participant.getId());
-                put("TESTING_EDC_BDRS_1_VALUE", participant.getDid());
                 put("EDC_IAM_TRUSTED-ISSUER_ISSUER_ID", trustedIssuer);
                 putAll(datasourceConfig());
             }
         };
+        addBdrsEnvs(env, participants);
+        return env;
     }
 
-    public Map<String, String> dataPlaneEnv(BaseParticipant participant) {
+    private void addBdrsEnvs(Map<String, String> env, List<BaseParticipant> participants) {
+        for (int i = 0; i < participants.size(); i++) {
+            env.put("TESTING_EDC_BDRS_" + (i + 1) + "_KEY", participants.get(i).getId());
+            env.put("TESTING_EDC_BDRS_" + (i + 1) + "_VALUE", participants.get(i).getDid());
+        }
+    }
 
 
-        return new HashMap<>() {
+    public Map<String, String> dataPlaneEnv(List<BaseParticipant> participant) {
+        Map<String, String> envs = new HashMap<>() {
             {
                 put("EDC_PARTICIPANT_ID", id);
                 put("EDC_COMPONENT_ID", id);
@@ -102,14 +109,14 @@ public class RemoteParticipant extends BaseParticipant {
                 put("TESTING_EDC_VAULTS_2_VALUE", getPrivateKeyAsString());
                 put("TESTING_EDC_VAULTS_3_KEY", "public-key");
                 put("TESTING_EDC_VAULTS_3_VALUE", getPublicKeyAsString());
-                put("TESTING_EDC_BDRS_1_KEY", participant.getId());
-                put("TESTING_EDC_BDRS_1_VALUE", participant.getDid());
                 put("EDC_IAM_ISSUER_ID", getDid());
                 put("EDC_IAM_TRUSTED-ISSUER_ISSUER_ID", trustedIssuer);
 
                 putAll(datasourceConfig());
             }
         };
+        addBdrsEnvs(envs, participant);
+        return envs;
     }
 
     private Map<String, String> datasourceConfig() {

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
@@ -19,141 +19,51 @@
 
 package org.eclipse.tractusx.edc.compatibility.tests.transfer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures;
+import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessStarted;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
-import org.eclipse.edc.junit.extensions.RuntimeExtension;
-import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
-import org.eclipse.edc.spi.iam.AudienceResolver;
-import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.tractusx.edc.compatibility.tests.AbstractTest;
 import org.eclipse.tractusx.edc.compatibility.tests.fixtures.BaseParticipant;
-import org.eclipse.tractusx.edc.compatibility.tests.fixtures.DataspaceIssuer;
-import org.eclipse.tractusx.edc.compatibility.tests.fixtures.EdcDockerRuntimes;
-import org.eclipse.tractusx.edc.compatibility.tests.fixtures.IdentityHubParticipant;
-import org.eclipse.tractusx.edc.compatibility.tests.fixtures.LocalParticipant;
-import org.eclipse.tractusx.edc.compatibility.tests.fixtures.RemoteParticipant;
-import org.eclipse.tractusx.edc.compatibility.tests.fixtures.Runtimes;
-import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.mockserver.model.HttpStatusCode;
+import org.mockserver.model.MediaType;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Stream;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.DEPROVISIONED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
-import static org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndInstance.createDatabase;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
-import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.configureParticipant;
-import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.configureParticipantContext;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 
 @EndToEndTest
-public class TransferEndToEndTest {
-
-    protected static final IdentityHubParticipant IDENTITY_HUB_PARTICIPANT = IdentityHubParticipant.Builder.newInstance()
-            .name("identity-hub")
-            .id("identity-hub")
-            .build();
-    
-    protected static final DataspaceIssuer ISSUER = DataspaceIssuer.Builder.newInstance().id("issuer").name("issuer")
-            .did(IDENTITY_HUB_PARTICIPANT.didFor("issuer"))
-            .build();
-
-    protected static final RemoteParticipant REMOTE_PARTICIPANT = RemoteParticipant.Builder.newInstance()
-            .name("remote")
-            .id("remote")
-            .sts(IDENTITY_HUB_PARTICIPANT.getSts())
-            .did(IDENTITY_HUB_PARTICIPANT.didFor("remote"))
-            .trustedIssuer(ISSUER.getDid())
-            .build();
-
-    protected static final LocalParticipant LOCAL_PARTICIPANT = LocalParticipant.Builder.newInstance()
-            .name("local")
-            .id("local")
-            .sts(IDENTITY_HUB_PARTICIPANT.getSts())
-            .did(IDENTITY_HUB_PARTICIPANT.didFor("local"))
-            .trustedIssuer(ISSUER.getDid())
-            .build();
-
-    private static final GenericContainer<?> REMOTE_DATA_PLANE = EdcDockerRuntimes.DATA_PLANE.create("dataplane", REMOTE_PARTICIPANT.dataPlaneEnv(LOCAL_PARTICIPANT));
-    private static final GenericContainer<?> REMOTE_CONTROL_PLANE = EdcDockerRuntimes.CONTROL_PLANE.create("controlplane", REMOTE_PARTICIPANT.controlPlaneEnv(LOCAL_PARTICIPANT));
-
-    @Order(1)
-    @RegisterExtension
-    static final RuntimeExtension LOCAL_CONTROL_PLANE = new RuntimePerClassExtension(
-            Runtimes.CONTROL_PLANE.create("local-control-plane", LOCAL_PARTICIPANT.controlPlanePostgresConfiguration()));
-
-    @Order(2)
-    @RegisterExtension
-    static final RuntimeExtension LOCAL_DATA_PLANE = new RuntimePerClassExtension(
-            Runtimes.DATA_PLANE.create("local-data-plane", LOCAL_PARTICIPANT.dataPlanePostgresConfiguration()));
-
-    @Order(1)
-    @RegisterExtension
-    static final RuntimeExtension LOCAL_IDENTITY_HUB = new RuntimePerClassExtension(
-            Runtimes.IDENTITY_HUB.create("local-identity-hub", IDENTITY_HUB_PARTICIPANT.getConfiguration()));
-
-    private static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:16.4")
-            .withUsername("postgres")
-            .withPassword("password")
-            .withCreateContainerCmdModifier(cmd -> cmd.withName("postgres"));
-
-    @Order(0)
-    @RegisterExtension
-    static final BeforeAllCallback BOOSTRAP = context -> {
-        var dids = Map.of(LOCAL_PARTICIPANT.getId(), LOCAL_PARTICIPANT.getDid(), REMOTE_PARTICIPANT.getId(), REMOTE_PARTICIPANT.getDid());
-        LOCAL_CONTROL_PLANE.registerServiceMock(BdrsClient.class, dids::get);
-        LOCAL_CONTROL_PLANE.registerServiceMock(AudienceResolver.class, message -> Result.success(dids.get(message.getCounterPartyId())));
-
-        PG.setPortBindings(List.of("5432:5432"));
-        PG.start();
-        createDatabase(LOCAL_PARTICIPANT.getName());
-        createDatabase(REMOTE_PARTICIPANT.getName());
-    };
-
-    private static ClientAndServer providerDataSource;
-
-    @BeforeAll
-    static void beforeAll() {
-        REMOTE_CONTROL_PLANE.start();
-        REMOTE_DATA_PLANE.start();
-        providerDataSource = startClientAndServer(getFreePort());
-        configureParticipant(LOCAL_PARTICIPANT, ISSUER, IDENTITY_HUB_PARTICIPANT, LOCAL_IDENTITY_HUB);
-        configureParticipant(REMOTE_PARTICIPANT, ISSUER, IDENTITY_HUB_PARTICIPANT, LOCAL_IDENTITY_HUB);
-        configureParticipantContext(ISSUER, IDENTITY_HUB_PARTICIPANT, LOCAL_IDENTITY_HUB);
-
-        var vault = LOCAL_DATA_PLANE.getService(Vault.class);
-        vault.storeSecret("private-key", LOCAL_PARTICIPANT.getPrivateKeyAsString());
-        vault.storeSecret("public-key", LOCAL_PARTICIPANT.getPublicKeyAsString());
-        vault.storeSecret("local-secret", "clientSecret");
-
-        var cpVault = LOCAL_CONTROL_PLANE.getService(Vault.class);
-        cpVault.storeSecret("local-secret", "clientSecret");
-    }
+public class TransferEndToEndTest extends AbstractTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @ParameterizedTest
     @ArgumentsSource(ParticipantsArgProvider.class)
@@ -161,32 +71,23 @@ public class TransferEndToEndTest {
         consumer.setProtocol(protocol);
         provider.setProtocol(protocol);
         provider.waitForDataPlane();
-        providerDataSource.when(HttpRequest.request()).respond(HttpResponse.response().withBody("data"));
-        var assetId = UUID.randomUUID().toString();
-        var sourceDataAddress = httpSourceDataAddress();
-        createResourcesOnProvider(provider, assetId, PolicyFixtures.contractExpiresIn("5s"), sourceDataAddress);
+        var assetId = provider.createResource(httpSourceDataAddress(), PolicyFixtures.contractExpiresIn("5s"));
 
-        var transferProcessId = consumer.requestAssetFrom(assetId, provider)
-                .withTransferType("HttpData-PULL")
-                .execute();
+        var transferProcessId = consumer.requestAssetFrom(assetId, provider).withTransferType("HttpData-PULL").execute();
 
         consumer.awaitTransferToBeInState(transferProcessId, STARTED);
 
-        var edr = await().atMost(consumer.getTimeout())
-                .until(() -> consumer.getEdr(transferProcessId), Objects::nonNull);
+        var edr = await().atMost(consumer.getTimeout()).until(() -> consumer.getEdr(transferProcessId), Objects::nonNull);
 
         // Do the transfer
         var msg = UUID.randomUUID().toString();
-        await().atMost(consumer.getTimeout())
-                .untilAsserted(() -> consumer.pullData(edr, Map.of("message", msg), body -> assertThat(body).isEqualTo("data")));
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> consumer.pullData(edr, Map.of("message", msg), body -> assertThat(body).isEqualTo("data")));
 
         // checks that the EDR is gone once the contract expires
-        await().atMost(consumer.getTimeout())
-                .untilAsserted(() -> assertThatThrownBy(() -> consumer.getEdr(transferProcessId)));
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> assertThatThrownBy(() -> consumer.getEdr(transferProcessId)));
 
         // checks that transfer fails
-        await().atMost(consumer.getTimeout())
-                .untilAsserted(() -> assertThatThrownBy(() -> consumer.pullData(edr, Map.of("message", msg), body -> assertThat(body).isEqualTo("data"))));
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> assertThatThrownBy(() -> consumer.pullData(edr, Map.of("message", msg), body -> assertThat(body).isEqualTo("data"))));
 
         providerDataSource.verify(HttpRequest.request("/source").withMethod("GET"));
 
@@ -195,16 +96,10 @@ public class TransferEndToEndTest {
     @ParameterizedTest
     @ArgumentsSource(ParticipantsArgProvider.class)
     void suspendAndResume_httpPull_dataTransfer(BaseParticipant consumer, BaseParticipant provider, String protocol) {
-        consumer.setProtocol(protocol);
-        provider.setProtocol(protocol);
-        provider.waitForDataPlane();
-        providerDataSource.when(HttpRequest.request()).respond(HttpResponse.response().withBody("data"));
-        var assetId = UUID.randomUUID().toString();
-        createResourcesOnProvider(provider, assetId, PolicyFixtures.noConstraintPolicy(), httpSourceDataAddress());
+        initialise(consumer, provider, protocol);
+        var assetId = provider.createResource(httpSourceDataAddress(), PolicyFixtures.noConstraintPolicy());
 
-        var transferProcessId = consumer.requestAssetFrom(assetId, provider)
-                .withTransferType("HttpData-PULL")
-                .execute();
+        var transferProcessId = consumer.requestAssetFrom(assetId, provider).withTransferType("HttpData-PULL").execute();
 
         consumer.awaitTransferToBeInState(transferProcessId, STARTED);
 
@@ -233,31 +128,85 @@ public class TransferEndToEndTest {
         providerDataSource.verify(HttpRequest.request("/source").withMethod("GET"));
     }
 
-    protected void createResourcesOnProvider(BaseParticipant provider, String assetId, JsonObject contractPolicy, Map<String, Object> dataAddressProperties) {
-        provider.createAsset(assetId, Map.of("description", "description"), dataAddressProperties);
-        var contractPolicyId = provider.createPolicyDefinition(contractPolicy);
-        var noConstraintPolicyId = provider.createPolicyDefinition(noConstraintPolicy());
-
-        provider.createContractDefinition(assetId, UUID.randomUUID().toString(), noConstraintPolicyId, contractPolicyId);
+    @ParameterizedTest
+    @ArgumentsSource(ParticipantsArgProvider.class)
+    void terminateTransferProcess(BaseParticipant consumer, BaseParticipant provider, String protocol) {
+        initialise(consumer, provider, protocol);
+        Map<String, Object> dataAddress = httpSourceDataAddress();
+        var assetId = provider.createResource(dataAddress, PolicyFixtures.noConstraintPolicy());
+        String transferProcessId = consumer.requestAssetFrom(assetId, provider).withTransferType("HttpData-PULL").execute();
+        consumer.awaitTransferToBeInState(transferProcessId, STARTED);
+        DataAddress edr = await().atMost(consumer.getTimeout()).until(() -> consumer.getEdr(transferProcessId), Objects::nonNull);
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> consumer.pullData(edr, Map.of(), body -> assertThat(body).isEqualTo("data")));
+        var providerTransferProcessId = provider.getTransferProcesses().stream().filter(filter -> filter.asJsonObject().getString("correlationId").equals(transferProcessId)).map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+        provider.terminateTransfer(providerTransferProcessId);
+        provider.awaitTransferToBeInState(providerTransferProcessId, DEPROVISIONED);
+        // checks that the EDR is gone once the transfer has been terminated
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> assertThatThrownBy(() -> consumer.getEdr(transferProcessId)));
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> assertThatThrownBy(() -> consumer.pullData(edr, Map.of(), body -> assertThat(body).isEqualTo("data"))));
+        providerDataSource.verify(HttpRequest.request("/source").withMethod("GET"));
     }
 
-    private @NotNull Map<String, Object> httpSourceDataAddress() {
-        return Map.of(
-                EDC_NAMESPACE + "name", "transfer-test",
-                EDC_NAMESPACE + "baseUrl", "http://localhost:" + providerDataSource.getPort() + "/source",
-                EDC_NAMESPACE + "type", "HttpData",
-                EDC_NAMESPACE + "proxyQueryParams", "true"
-        );
+    @ParameterizedTest
+    @ArgumentsSource(ParticipantsArgProvider.class)
+    void deprovisionShouldFailOnceTransferProcessHasStarted(BaseParticipant consumer, BaseParticipant provider, String protocol) {
+        initialise(consumer, provider, protocol);
+        Map<String, Object> dataAddress = httpSourceDataAddress();
+        var assetId = provider.createResource(dataAddress, PolicyFixtures.noConstraintPolicy());
+        String transferProcessId = consumer.requestAssetFrom(assetId, provider).withTransferType("HttpData-PULL").execute();
+        consumer.awaitTransferToBeInState(transferProcessId, STARTED);
+        assertThatThrownBy(() -> consumer.deprovisionTransfer(transferProcessId)).hasMessageContaining("Expected status code <204> but was <409>");
+        DataAddress edr = await().atMost(consumer.getTimeout()).until(() -> consumer.getEdr(transferProcessId), Objects::nonNull);
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> consumer.pullData(edr, Map.of(), body -> assertThat(body).isEqualTo("data")));
+        providerDataSource.verify(HttpRequest.request("/source").withMethod("GET"));
     }
 
-    private static class ParticipantsArgProvider implements ArgumentsProvider {
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(
-                    Arguments.of(REMOTE_PARTICIPANT, LOCAL_PARTICIPANT, "dataspace-protocol-http"),
-                    Arguments.of(LOCAL_PARTICIPANT, REMOTE_PARTICIPANT, "dataspace-protocol-http")
-            );
+
+    @ParameterizedTest
+    @ArgumentsSource(ParticipantsArgProvider.class)
+    void httpPull_dataTransfer_withCallbacks(BaseParticipant consumer, BaseParticipant provider, String protocol) {
+        initialise(consumer, provider, protocol);
+        Map<String, Object> dataAddress = httpSourceDataAddress();
+        var callbacksEndpoint = startClientAndServer(getFreePort());
+        var assetId = provider.createResource(dataAddress, PolicyFixtures.noConstraintPolicy());
+        var callbackUrl = String.format("http://localhost:%d/hooks", callbacksEndpoint.getLocalPort());
+        var callbacks = Json.createArrayBuilder().add(createCallback(callbackUrl, true, Set.of("transfer.process.started"))).build();
+
+        var request = request().withPath("/hooks").withMethod(HttpMethod.POST.name());
+
+        var events = new ConcurrentHashMap<String, TransferProcessStarted>();
+
+        callbacksEndpoint.when(request).respond(req -> this.cacheEdr(req, events));
+
+        var transferProcessId = consumer.requestAssetFrom(assetId, provider).withTransferType("HttpData-PULL").withCallbacks(callbacks).execute();
+
+        consumer.awaitTransferToBeInState(transferProcessId, STARTED);
+
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> assertThat(events.get(transferProcessId)).isNotNull());
+        var event = events.get(transferProcessId);
+        var msg = UUID.randomUUID().toString();
+        await().atMost(consumer.getTimeout()).untilAsserted(() -> consumer.pullData(event.getDataAddress(), Map.of("message", msg), body -> assertThat(body).isEqualTo("data")));
+
+        providerDataSource.verify(request("/source").withMethod("GET"));
+    }
+
+
+    private HttpResponse cacheEdr(HttpRequest request, Map<String, TransferProcessStarted> events) {
+
+        try {
+            var event = MAPPER.readValue(request.getBody().toString(), new TypeReference<EventEnvelope<TransferProcessStarted>>() {
+            });
+            events.put(event.getPayload().getTransferProcessId(), event.getPayload());
+            return response().withStatusCode(HttpStatusCode.OK_200.code()).withHeader(HttpHeaderNames.CONTENT_TYPE.toString(), MediaType.PLAIN_TEXT_UTF_8.toString()).withBody("{}");
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
         }
+    }
+
+    private JsonObject createCallback(String url, boolean transactional, Set<String> events) {
+        return Json.createObjectBuilder().add(TYPE, EDC_NAMESPACE + "CallbackAddress").add(EDC_NAMESPACE + "transactional", transactional).add(EDC_NAMESPACE + "uri", url)
+                .add(EDC_NAMESPACE + "events", events.stream().collect(Json::createArrayBuilder, JsonArrayBuilder::add, JsonArrayBuilder::add).build()).build();
     }
 
 }

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
@@ -161,7 +161,6 @@ public class TransferEndToEndTest extends AbstractTest {
         providerDataSource.verify(HttpRequest.request("/source").withMethod("GET"));
     }
 
-
     @ParameterizedTest
     @ArgumentsSource(ParticipantsArgProvider.class)
     void httpPull_dataTransfer_withCallbacks(BaseParticipant consumer, BaseParticipant provider, String protocol) {
@@ -189,7 +188,6 @@ public class TransferEndToEndTest extends AbstractTest {
 
         providerDataSource.verify(request("/source").withMethod("GET"));
     }
-
 
     private HttpResponse cacheEdr(HttpRequest request, Map<String, TransferProcessStarted> events) {
 


### PR DESCRIPTION
## Description
Introducing the support for matrix combination for testing different versions of connectors with different protocols.
Earlier these were hardcoded in the test, which is not practical to maintain as the test landscape grows.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Issue - https://github.com/eclipse-tractusx/tractusx-edc-compatibility-tests/issues/30

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

## Additional Information

Currently there is only one test class where all the configurations are hardcoded. This also includes the combinations of connector version and protocol versions. With this setup the test landscape will not scale as we will more versions coming up in the future and to ensure the compatibility among all the versions we need to have a matrix combination setup in the test.

To solve this problem, this pr contains an Abstraction of the configurations, that later the test classes can simply extend.   
This will help the tester to forget about the system setup and focus only on the test cases.  
More addition to the abstraction, now multiple connector version can be tested by including one more runtime folder for that specific version. 
Later by adding one more field in the `EdcDockerRuntimes.java` for the new runtime, you can simply refer this in the abstract class to include the runtime for testing. 
Same for protocol, whenever there is a new protocol that needs to be tested, simply add the new protocol to the abstract class and the combinations will be automatically created inside the test itself. 

Additionally, more test cases were also added to `TransferEndToEndTest.java` for a better coverage of scenario.

With this feature in place, it will be now easy to add more test scenarios to the kit.

@wolf4ood Thanks for creating the template tests and feel free to add your thoughts here. It would be great if you can take a look at the PR as well