### PR TITLE
chore: add codeowners file to define standard reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Identify the committers responsible for the repository as standard reviewers
+
+* @rafaelmag110 @ndr-brt @lgblaumeiser


### PR DESCRIPTION
## WHAT

Add a codeowners file to ensure the committers being added as reviewers

## WHY

To prevent wrong proposals for reviewers and to control who gets notified on changes
