### PR TITLE
chore: Update snapshot and stable version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,10 @@ val edcScmConnection: String by project
 
 buildscript {
     dependencies {
+        val edcBuildVersion: String by project
         val edcVersion: String by project
-        classpath("org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin:${edcVersion}")
+        classpath("org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin:${edcBuildVersion}")
+        classpath("org.eclipse.edc.autodoc:org.eclipse.edc.autodoc.gradle.plugin:$edcVersion")
     }
 }
 
@@ -37,6 +39,8 @@ allprojects {
     val edcVersion: String by project
     val edcGroup: String by project
     apply(plugin = "${edcGroup}.edc-build")
+    apply(plugin = "org.eclipse.edc.autodoc")
+
     // configure which version of the annotation processor to use. defaults to the same version as the plugin
     configure<org.eclipse.edc.plugins.autodoc.AutodocExtension> {
         processorVersion.set(edcVersion)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 ################################################################################
 group=org.eclipse.tractusx.edc
 edcGroup=org.eclipse.edc
-version=0.11.0-RC2
+version=0.11.0-SNAPSHOT
 edcVersion=0.14.0
 edcBuildVersion=1.0.0
 edcScmUrl=https://github.com/eclipse-tractusx/tractusx-edc-compatibility-tests.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 ################################################################################
 group=org.eclipse.tractusx.edc
 edcGroup=org.eclipse.edc
-version=0.9.0
-edcVersion=0.11.1
+version=0.11.0-20250721-SNAPSHOT
+edcVersion=0.14.0-20250719-SNAPSHOT
 edcScmUrl=https://github.com/eclipse-tractusx/tractusx-edc-compatibility-tests.git
 edcScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc-compatibility-tests.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 ################################################################################
 group=org.eclipse.tractusx.edc
 edcGroup=org.eclipse.edc
-version=0.9.0-SNAPSHOT
-edcVersion=0.11.0-20241230-SNAPSHOT
+version=0.9.0
+edcVersion=0.11.1
 edcScmUrl=https://github.com/eclipse-tractusx/tractusx-edc-compatibility-tests.git
 edcScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc-compatibility-tests.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,8 @@
 ################################################################################
 group=org.eclipse.tractusx.edc
 edcGroup=org.eclipse.edc
-version=0.11.0-20250721-SNAPSHOT
-edcVersion=0.14.0-20250719-SNAPSHOT
+version=0.11.0-RC2
+edcVersion=0.14.0
+edcBuildVersion=1.0.0
 edcScmUrl=https://github.com/eclipse-tractusx/tractusx-edc-compatibility-tests.git
 edcScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc-compatibility-tests.git

--- a/gradle/libs.stable.versions.toml
+++ b/gradle/libs.stable.versions.toml
@@ -2,8 +2,8 @@
 format.version = "1.1"
 
 [versions]
-tractusx = "0.7.7"
-edc = "0.7.2"
+tractusx = "0.9.0"
+edc = "0.11.1"
 
 [libraries]
 tx-edc-controlplane-postgresql-hashicorp-vault = { module = "org.eclipse.tractusx.edc:edc-controlplane-postgresql-hashicorp-vault", version.ref = "tractusx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,9 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.14.0-20250719-SNAPSHOT"
-tractusx = "0.11.0-20250721-SNAPSHOT"
+edc = "0.14.0"
+edc-build = "1.0.0"
+tractusx = "0.11.0-RC2"
 awaitility = "4.3.0"
 httpMockServer = "5.15.0"
 jackson = "2.20.0"
@@ -42,3 +43,4 @@ testcontainers-postgres = { module = "org.testcontainers:postgresql", version.re
 [plugins]
 shadow = { id = "com.gradleup.shadow", version = "8.3.8" }
 docker = { id = "com.bmuschko.docker-remote-api", version = "9.4.0" }
+edc-build = { id = "org.eclipse.edc.edc-build", version.ref = "edc-build" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.14.0-20250607-SNAPSHOT"
-tractusx = "0.10.0-20250609-SNAPSHOT"
+edc = "0.14.0-20250626-SNAPSHOT"
+tractusx = "0.11.0-20250714-SNAPSHOT"
 awaitility = "4.3.0"
 httpMockServer = "5.15.0"
 jackson = "2.20.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ format.version = "1.1"
 [versions]
 edc = "0.14.0"
 edc-build = "1.0.0"
-tractusx = "0.11.0-RC2"
+tractusx = "0.11.0-SNAPSHOT"
 awaitility = "4.3.0"
 httpMockServer = "5.15.0"
 jackson = "2.20.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.14.0-20250626-SNAPSHOT"
-tractusx = "0.11.0-20250714-SNAPSHOT"
+edc = "0.14.0-20250719-SNAPSHOT"
+tractusx = "0.11.0-20250721-SNAPSHOT"
 awaitility = "4.3.0"
 httpMockServer = "5.15.0"
 jackson = "2.20.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,9 +26,6 @@ pluginManagement {
         maven {
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -39,9 +36,6 @@ dependencyResolutionManagement {
         mavenLocal()
         maven {
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-        }
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
         }
         mavenCentral()
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        }
+        maven {
             url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
         }
         mavenCentral()
@@ -34,6 +37,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenLocal()
+        maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        }
         maven {
             url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
         }

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/BaseParticipant.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/BaseParticipant.java
@@ -143,7 +143,7 @@ public abstract class BaseParticipant extends Participant {
         var dataAddressRaw = baseManagementRequest()
                 .contentType(JSON)
                 .when()
-                .get("/v2/edrs/{id}/dataaddress", transferProcessId)
+                .get("/v3/edrs/{id}/dataaddress", transferProcessId)
                 .then()
                 .log().ifError()
                 .statusCode(200)

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/DataspaceIssuer.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/DataspaceIssuer.java
@@ -46,9 +46,12 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.bpnSubject;
 import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.createVc;
 import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.frameworkAgreementSubject;
 import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.membershipSubject;
+
+
 
 /**
  * Dataspace issuer configurations
@@ -90,6 +93,13 @@ public class DataspaceIssuer extends BaseParticipant {
                 membershipSubject(did, bpn));
     }
 
+    public VerifiableCredentialResource issueBpnCredential(String did, String bpn) {
+        return issueCredential(did, bpn, "BpnCredential", () -> CredentialSubject.Builder.newInstance()
+                .claim("holderIdentifier", bpn)
+                .build(),
+                bpnSubject(did, bpn));
+    }
+
     public VerifiableCredentialResource issueDismantlerCredential(String did, String bpn) {
         return issueCredential(did, bpn, "DismantlerCredential", () -> CredentialSubject.Builder.newInstance()
                         .id(did)
@@ -106,11 +116,11 @@ public class DataspaceIssuer extends BaseParticipant {
                         .build());
     }
 
-    public VerifiableCredentialResource issueFrameworkCredential(String did, String bpn, String credentialType) {
-        return issueCredential(did, bpn, credentialType, () -> CredentialSubject.Builder.newInstance()
+    public VerifiableCredentialResource issueFrameworkCredential(String did, String bpn) {
+        return issueCredential(did, bpn, "DataExchangeGovernanceCredential", () -> CredentialSubject.Builder.newInstance()
                         .claim("holderIdentifier", bpn)
                         .build(),
-                frameworkAgreementSubject(did, bpn, credentialType));
+                frameworkAgreementSubject(did, bpn));
 
     }
 
@@ -136,9 +146,9 @@ public class DataspaceIssuer extends BaseParticipant {
     public List<VerifiableCredentialResource> issueCredentials(BaseParticipant participant) {
         return List.of(
                 issueMembershipCredential(participant.getDid(), participant.getId()),
+                issueBpnCredential(participant.getDid(), participant.getId()),
                 issueDismantlerCredential(participant.getDid(), participant.getId()),
-                issueFrameworkCredential(participant.getDid(), participant.getId(), "PcfCredential"),
-                issueFrameworkCredential(participant.getDid(), participant.getId(), "DataExchangeGovernanceCredential"));
+                issueFrameworkCredential(participant.getDid(), participant.getId()));
     }
 
     private String signJwt(ECKey privateKey, String issuerId, String subject, String audience, Map<String, Object> claims) {

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/DcpHelperFunctions.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/DcpHelperFunctions.java
@@ -53,16 +53,25 @@ public class DcpHelperFunctions {
 
     public static JsonObject membershipSubject(String did, String id) {
         return Json.createObjectBuilder()
-                .add("type", "MembershipCredential")
                 .add("holderIdentifier", id)
                 .add("id", did)
+                .add("memberOf", "Catena-X")
                 .build();
 
     }
 
-    public static JsonObject frameworkAgreementSubject(String did, String id, String type) {
+    public static JsonObject bpnSubject(String did, String id) {
         return Json.createObjectBuilder()
-                .add("type", type)
+                .add("holderIdentifier", id)
+                .add("id", did)
+                .add("bpn", id)
+                .build();
+
+    }
+
+    public static JsonObject frameworkAgreementSubject(String did, String id) {
+        return Json.createObjectBuilder()
+                .add("type", "DataExchangeGovernanceCredential")
                 .add("holderIdentifier", id)
                 .add("contractVersion", "1.0.0")
                 .add("contractTemplate", "https://public.catena-x.org/contracts/traceabilty.v1.pdf")

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/LocalParticipant.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/LocalParticipant.java
@@ -37,7 +37,8 @@ public class LocalParticipant extends BaseParticipant {
     public Config controlPlaneConfig() {
         Map<String, String> settings = new HashMap<>() {
             {
-                put(PARTICIPANT_ID, id);
+                put(PARTICIPANT_ID, getDid());
+                put("tractusx.edc.participant.bpn", id);
                 put("web.http.port", String.valueOf(getFreePort()));
                 put("web.http.path", "/api");
                 put("web.http.protocol.port", String.valueOf(controlPlaneProtocol.get().getPort()));

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/PolicyHelperFunctions.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/fixtures/PolicyHelperFunctions.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2025 Cofinity-x GmbH
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.compatibility.tests.fixtures;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import java.util.List;
+
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.atomicConstraint;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.policy;
+
+
+public class PolicyHelperFunctions {
+
+    public static JsonObject contractExpiresIn(String offset) {
+        return inForceDatePolicyLegacy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+" + offset);
+    }
+
+    private static JsonObject inForceDatePolicyLegacy(String operatorStart, Object startDate, String operatorEnd, Object endDate) {
+        var constraint = Json.createObjectBuilder()
+                .add("@type", "LogicalConstraint")
+                .add("and", Json.createArrayBuilder()
+                        .add(atomicConstraint("https://w3id.org/edc/v0.0.1/ns/inForceDate", operatorStart, startDate))
+                        .add(atomicConstraint("https://w3id.org/edc/v0.0.1/ns/inForceDate", operatorEnd, endDate))
+                        .add(atomicConstraint("https://w3id.org/catenax/policy/Membership", "eq", "active"))
+                        .build())
+                .build();
+
+        return policy(List.of(Json.createObjectBuilder()
+                .add("action", "use")
+                .add("constraint", constraint)
+                .build()));
+    }
+}

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
@@ -67,7 +67,6 @@ import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFun
 import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.configureParticipantContext;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
-
 @EndToEndTest
 public class TransferEndToEndTest {
 
@@ -118,9 +117,21 @@ public class TransferEndToEndTest {
             Runtimes.CONTROL_PLANE.create("local-control-plane")
                     .configurationProvider(() -> POSTGRESQL.configFor(LOCAL_PARTICIPANT.getName()))
                     .configurationProvider(LOCAL_PARTICIPANT::controlPlaneConfig)
-                    .registerServiceMock(BdrsClient.class, DIDS::get)
-                    .registerServiceMock(AudienceResolver.class, message -> Result.success(DIDS.get(message.getCounterPartyId())))
-    );
+                    .registerServiceMock(BdrsClient.class, new BdrsClient() {
+                        @Override
+                        public String resolveDid(String bpn) {
+                            return DIDS.get(bpn);
+                        }
+
+                        @Override
+                        public String resolveBpn(String did) {
+                            return DIDS.entrySet().stream()
+                                    .filter(entry -> entry.getValue().equals(did))
+                                    .findFirst().orElseThrow().getKey();
+                        }
+                    })
+                    .registerServiceMock(AudienceResolver.class, message -> Result
+                            .success(DIDS.get(message.getCounterPartyId()))));
 
     @Order(2)
     @RegisterExtension

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
@@ -65,6 +65,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.configureParticipant;
 import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.DcpHelperFunctions.configureParticipantContext;
+import static org.eclipse.tractusx.edc.compatibility.tests.fixtures.PolicyHelperFunctions.contractExpiresIn;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 @EndToEndTest
@@ -177,9 +178,8 @@ public class TransferEndToEndTest {
         provider.waitForDataPlane();
         providerDataSource.when(HttpRequest.request()).respond(HttpResponse.response().withBody("data"));
         var assetId = UUID.randomUUID().toString();
-        var sourceDataAddress = httpSourceDataAddress();
-        // TODO: Add a more sophisticated policy here
-        createResourcesOnProvider(provider, assetId, PolicyFixtures.noConstraintPolicy(), sourceDataAddress);
+
+        createResourcesOnProvider(provider, assetId, contractExpiresIn("5s"), httpSourceDataAddress());
 
         var transferProcessId = consumer.requestAssetFrom(assetId, provider)
                 .withTransferType("HttpData-PULL")

--- a/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
+++ b/tests/compatibility-tests/src/test/java/org/eclipse/tractusx/edc/compatibility/tests/transfer/TransferEndToEndTest.java
@@ -178,7 +178,8 @@ public class TransferEndToEndTest {
         providerDataSource.when(HttpRequest.request()).respond(HttpResponse.response().withBody("data"));
         var assetId = UUID.randomUUID().toString();
         var sourceDataAddress = httpSourceDataAddress();
-        createResourcesOnProvider(provider, assetId, PolicyFixtures.contractExpiresIn("5s"), sourceDataAddress);
+        // TODO: Add a more sophisticated policy here
+        createResourcesOnProvider(provider, assetId, PolicyFixtures.noConstraintPolicy(), sourceDataAddress);
 
         var transferProcessId = consumer.requestAssetFrom(assetId, provider)
                 .withTransferType("HttpData-PULL")


### PR DESCRIPTION
## Description

Updates the used connector to the latest snapshot

Update counterpart from 0.7.7 to 0.9.0, as this is the official Io release version.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

Fixes #75 