### PR TITLE
Update to 0.12.0 development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@
 ################################################################################
 group=org.eclipse.tractusx.edc
 edcGroup=org.eclipse.edc
-version=0.11.0-SNAPSHOT
-edcVersion=0.14.0
-edcBuildVersion=1.0.0
+version=0.12.0-SNAPSHOT
+edcVersion=0.14.1
+edcBuildVersion=1.1.1
 edcScmUrl=https://github.com/eclipse-tractusx/tractusx-edc-compatibility-tests.git
 edcScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc-compatibility-tests.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.14.0"
+edc = "0.14.1"
 edc-build = "1.1.1"
-tractusx = "0.11.0-SNAPSHOT"
+tractusx = "0.12.0-SNAPSHOT"
 awaitility = "4.3.0"
 httpMockServer = "5.15.0"
 jackson = "2.20.0"


### PR DESCRIPTION
## Description

Use 0.12.0-SNAPSHOT version and 0.14.1 upstream version

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
