### PR TITLE
chore: Dependabot should not update edc dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
     labels:
       - "dependabot"
       - "java"
+    ignore:
+      - dependency-name: "org.eclipse.tractusx.edc:*"
+      - dependency-name: "org.eclipse.edc:*"
 
   # Docker CP stable
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Description

The edc dependencies upstream and downstream are actively managed by us, dependabot is only disturbing.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
